### PR TITLE
Added 8085 CPU support

### DIFF
--- a/IctUsbInterface/IctUsbInterface.ino
+++ b/IctUsbInterface/IctUsbInterface.ino
@@ -38,6 +38,7 @@
 #include <C6502Cpu.h>
 #include <CZ80Cpu.h>
 #include <C6809ECpu.h>
+#include <C8085Cpu.h>
 
 enum ResultCodes
 {
@@ -531,6 +532,27 @@ void SetCpu(String p_parameters)
     
     DisplayStatusInfo("6809 CPU Mode");
     SendResponse(Success, "CPU Set to 6809");
+  }
+  else if (p_parameters == "8085")
+  {
+	m_currentCpu = new C8085Cpu();
+	if (m_currentCpu == nullptr)
+	{
+	  DisplayStatusInfo("Error! 8085 CPU Mode");
+	  SendResponse(Error, "Could not create the 8085 CPU object.");
+	  return;
+	}
+
+	cpuResult = m_currentCpu->idle();
+	if (cpuResult->code != ERROR_SUCCESS)
+	{
+	  DisplayCommandDetails("Error! " + cpuResult->description);
+	  SendResponse(Error, cpuResult->description);
+	  return;
+	}
+
+	DisplayStatusInfo("8085 CPU Mode");
+	SendResponse(Success, "CPU Set to 8085");
   }
   else if (p_parameters == "8088")
   {


### PR DESCRIPTION
I put a post on UKVAC about this months ago and have finally today been using it so had a chance to test it. All the ROM CRC tests I was doing worked just fine so I have every reason to suspect this is completely working, but RAM tests were not working. I believe that is down to shared RAM access in Phoenix as per the notes in Paul Swann's 8085 implementation and nothing to do with this addition.

Obviously to get 8085 CPU support you also need to add the 8085.h file from the main repo just like any other CPU.

On my side, I also had to change the 6809E includes from plain 6809E to 6809E clock mastered otherwise I could not get the project to compile but since that was outside the scope of this PR I haven't included those very simple changes.